### PR TITLE
Disable ligatures for a more console-like feel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -13,6 +13,7 @@ body {
 	color: white;
 	font-size: 1em;
 	font-family: 'Meslo', monospace;
+	font-feature-settings: "liga" 0;
 }
 
 pre {


### PR DESCRIPTION
Prevents characters like `f` and `i` from combining
